### PR TITLE
Fixed http 404 if using GetUserAsync with non-null options

### DIFF
--- a/TwitterSharp/Client/TwitterClient.cs
+++ b/TwitterSharp/Client/TwitterClient.cs
@@ -271,7 +271,7 @@ namespace TwitterSharp.Client
         public async Task<User> GetUserAsync(string username, UserOption[] options = null)
         {
             var url = _baseUrl + "users/by/username/" + HttpUtility.UrlEncode(username);
-            AddUserOptions(ref url, options, false, false);
+            AddUserOptions(ref url, options, false, true);
             var str = await _httpClient.GetStringAsync(url);
             return ParseData<User>(str).Data;
         }


### PR DESCRIPTION
AddUserOptions is called with `isFirstLink: false` when it should have been `true`. This PR fixes the mistake.

Currently this bug can be worked around by using GetUsersAsync, which does not have this problem.

Disclaimer: I have not actually tested this, I'm 99% sure it should work after reading the code in my IDE's decompiler.