### PR TITLE
Fix for Expression AND-logic - There are no "written" AND operator

### DIFF
--- a/src/Rule/Expression.cs
+++ b/src/Rule/Expression.cs
@@ -27,7 +27,7 @@ namespace TwitterSharp.Rule
         /// Tweet match all the expressions given in parameter
         /// </summary>
         public Expression And(params Expression[] others)
-            => new("(" + _internal + " AND " + string.Join(" AND ", others.Select(x => x.ToString())) + ")", "");
+            => new("(" + _internal + " " + string.Join(" ", others.Select(x => x.ToString())) + ")", "");
 
         /// <summary>
         /// Tweet match the negation of the current expression


### PR DESCRIPTION
https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/integrate/build-a-rule#boolean

AND:
"Successive operators with a space between them will result in boolean "AND" logic, meaning that Tweets will match only if both conditions are met. For example, snow day #NoSchool will match Tweets containing the terms snow and day and the hashtag #NoSchool."