### PR TITLE
Fix ReplySettings JSON Converter

### DIFF
--- a/src/JsonOption/ReplySettingsConverter.cs
+++ b/src/JsonOption/ReplySettingsConverter.cs
@@ -14,7 +14,7 @@ namespace TwitterSharp.JsonOption
                 case "everyone":
                     return ReplySettings.Everyone;
 
-                case "mentionned_users":
+                case "mentionedUsers":
                     return ReplySettings.MentionnedUsers;
 
                 case "followers":

--- a/src/JsonOption/ReplySettingsConverter.cs
+++ b/src/JsonOption/ReplySettingsConverter.cs
@@ -17,7 +17,7 @@ namespace TwitterSharp.JsonOption
                 case "mentionedUsers":
                     return ReplySettings.MentionnedUsers;
 
-                case "followers":
+                case "following":
                     return ReplySettings.Followers;
 
                 default:


### PR DESCRIPTION
Typo in mentionedUsers + following

https://developer.twitter.com/en/docs/twitter-api/tweets/lookup/api-reference/get-tweets:

reply_settings: string

"Shows who can reply to this Tweet. Fields returned are everyone, mentionedUsers, and following.

To return this field, add tweet.fields=reply_settings in the request's query parameter."