### PR TITLE
Get recent / all tweets

### DIFF
--- a/test/TestTweet.cs
+++ b/test/TestTweet.cs
@@ -7,6 +7,7 @@ using TwitterSharp.Request.AdvancedSearch;
 using TwitterSharp.Request.Option;
 using TwitterSharp.Response.RMedia;
 using TwitterSharp.Response.RTweet;
+using TwitterSharp.Rule;
 
 namespace TwitterSharp.UnitTests
 {
@@ -437,6 +438,18 @@ namespace TwitterSharp.UnitTests
             Assert.IsNull(a.ReplySettings);
             Assert.IsNotNull(a.Source);
             Assert.AreEqual("Twitter for iPhone", a.Source);
+        }
+
+        [TestMethod]
+        public async Task GetRecentTweets()
+        {
+            var hashtag = "Test";
+            var client = new TwitterClient(Environment.GetEnvironmentVariable("TWITTER_TOKEN"));
+
+            // note: retweets are truncated at 140 characters, so i had to exclude them for making the check reliable
+            var a = await client.GetRecentTweets(Expression.Hashtag(hashtag).And(Expression.IsRetweet().Negate()));
+            
+            Assert.IsTrue(a.All(x => x.Text.Contains("#"+hashtag, StringComparison.InvariantCultureIgnoreCase)));
         }
 
         [TestMethod]


### PR DESCRIPTION
Implemented Search Tweets endpoints `tweets/search/recent` and `tweets/search/all`
Write test for recent (all needs academic research access)

completed this project task [Search tweets](https://github.com/Xwilarg/TwitterSharp/projects/1#card-60700406) and this [Full-archive search](https://github.com/Xwilarg/TwitterSharp/projects/1#card-60700432) (?)

\+ Add RateLimits builder to all other Tweet Search methods (now all methods are covered)