### PR TITLE
User Verified/Protected Fix

### DIFF
--- a/src/Response/RUser/User.cs
+++ b/src/Response/RUser/User.cs
@@ -43,7 +43,7 @@ namespace TwitterSharp.Response.RUser
         /// <summary>
         /// Are the user tweet private
         /// </summary>
-        public bool? IsProtected { init; get; }
+        public bool? Protected { init; get; }
         /// <summary>
         /// URL specified on user profile
         /// </summary>
@@ -59,7 +59,7 @@ namespace TwitterSharp.Response.RUser
         /// <summary>
         /// If the user is a verified Twitter user
         /// </summary>
-        public bool? IsVerified { init; get; }
+        public bool? Verified { init; get; }
 
         public override bool Equals(object obj)
             => obj is User t && t?.Id == Id;

--- a/test/TestUser.cs
+++ b/test/TestUser.cs
@@ -58,7 +58,7 @@ namespace TwitterSharp.UnitTests
             var client = new TwitterClient(Environment.GetEnvironmentVariable("TWITTER_TOKEN"));
             var answer = await client.GetUsersAsync(new[] { "theindra5" }, new UserSearchOptions
             {
-                UserOptions = new[] { UserOption.Description, UserOption.Public_Metrics }
+                UserOptions = new[] { UserOption.Description, UserOption.Public_Metrics, UserOption.Verified, UserOption.Protected }
             });
             Assert.IsTrue(answer.Length == 1);
             Assert.AreEqual("1022468464513089536", answer[0].Id);
@@ -66,7 +66,8 @@ namespace TwitterSharp.UnitTests
             Assert.AreEqual("Indra", answer[0].Name);
             Assert.IsNotNull(answer[0].Description);
             Assert.IsNotNull(answer[0].PublicMetrics);
-            Assert.IsNull(answer[0].Verified);
+            Assert.IsFalse(answer[0].Verified != null && answer[0].Verified.Value);
+            Assert.IsFalse(answer[0].Protected != null && answer[0].Protected.Value);
         }
     }
 }

--- a/test/TestUser.cs
+++ b/test/TestUser.cs
@@ -66,7 +66,7 @@ namespace TwitterSharp.UnitTests
             Assert.AreEqual("Indra", answer[0].Name);
             Assert.IsNotNull(answer[0].Description);
             Assert.IsNotNull(answer[0].PublicMetrics);
-            Assert.IsNull(answer[0].IsVerified);
+            Assert.IsNull(answer[0].Verified);
         }
     }
 }


### PR DESCRIPTION
The user properties "IsVerified" and "IsProtected" are actual "verified" and "protected", so they never serialized correctly.
Fixed that.