### PR TITLE
Add author_id to tweet.fields

### DIFF
--- a/src/Request/AdvancedSearch/TweetOption.cs
+++ b/src/Request/AdvancedSearch/TweetOption.cs
@@ -11,6 +11,11 @@
         // promoted_metrics
 
         /// <summary>
+        /// The ID of the author of the tweet
+        /// </summary>
+        Author_Id,
+
+        /// <summary>
         /// The ID of the tweet this one is replying to
         /// </summary>
         Conversation_Id,

--- a/src/Request/Option/ASearchOptions.cs
+++ b/src/Request/Option/ASearchOptions.cs
@@ -59,6 +59,10 @@ namespace TwitterSharp.Request.Option
                     {
                         return "attachments";
                     }
+                    if (x == TweetOption.Author_Id)
+                    {
+                        return "author_id";
+                    }
                     return x.ToString().ToLowerInvariant();
                 }));
             }


### PR DESCRIPTION
This commit allows you to read the `author_id` from tweets by adding the new enum option `TweetOptions.Author_Id`