### PR TITLE
Add GetMe endpoint to TwitterClient

### DIFF
--- a/src/ApiEndpoint/Endpoint.cs
+++ b/src/ApiEndpoint/Endpoint.cs
@@ -92,6 +92,9 @@ namespace TwitterSharp.ApiEndpoint
 
         #region Users
 
+        [Endpoint(Resource = Resource.Users, EndpointType = EndpointType.GET, Url = "/2/users/me", Group = "Authenticated user", LimitPerUser = 75)]
+        [Description("Retrieve the currently authenticated user")]
+        GetMe,
         [Endpoint(Resource = Resource.Users, EndpointType = EndpointType.GET, Url = "/2/users/by/username/:username", Group = "User lookup", LimitPerApp = 300, LimitPerUser = 900)]
         [Description("Retrieve a single user with a usernames")]
         GetUserByName,

--- a/src/ApiEndpoint/Endpoint.cs
+++ b/src/ApiEndpoint/Endpoint.cs
@@ -92,7 +92,7 @@ namespace TwitterSharp.ApiEndpoint
 
         #region Users
 
-        [Endpoint(Resource = Resource.Users, EndpointType = EndpointType.GET, Url = "/2/users/me", Group = "Authenticated user", LimitPerUser = 75)]
+        [Endpoint(Resource = Resource.Users, EndpointType = EndpointType.GET, Url = "/2/users/me", Group = "User lookup", LimitPerUser = 75)]
         [Description("Retrieve the currently authenticated user")]
         GetMe,
         [Endpoint(Resource = Resource.Users, EndpointType = EndpointType.GET, Url = "/2/users/by/username/:username", Group = "User lookup", LimitPerApp = 300, LimitPerUser = 900)]

--- a/src/Client/TwitterClient.cs
+++ b/src/Client/TwitterClient.cs
@@ -366,6 +366,17 @@ namespace TwitterSharp.Client
 
         #region UserSearch
         /// <summary>
+        /// Gets the currently authorized user
+        /// </summary>
+        public async Task<User> GetMeAsync(UserSearchOptions options = null)
+        {
+            options ??= new();
+            var res = await _httpClient.GetAsync(_baseUrl + "users/me" + "?" + options.Build(false));
+            BuildRateLimit(res.Headers, Endpoint.GetMe);
+            return ParseData<User>(await res.Content.ReadAsStringAsync()).Data;
+        }
+
+        /// <summary>
         /// Get an user given his username
         /// </summary>
         /// <param name="username">Username of the user you want information about</param>


### PR DESCRIPTION
TwitterClient was missing the /2/users/me endpoint as supported by Twitter API V2.

https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-me