### PR TITLE
Get Liked Tweets by User Id

### DIFF
--- a/src/Client/TwitterClient.cs
+++ b/src/Client/TwitterClient.cs
@@ -249,6 +249,19 @@ namespace TwitterSharp.Client
             return ParseArrayData<Tweet>(await res.Content.ReadAsStringAsync());
         }
 
+        /// <summary>
+        /// Get the tweets liked by a user
+        /// </summary>
+        /// <param name="userId">User ID of the user you want the linked tweets of</param>
+        /// <param name="options">properties send with the tweet</param>
+        public async Task<Tweet[]> GetLikedTweets(string userId, TweetSearchOptions options = null)
+        {
+            options ??= new();
+            var res = await _httpClient.GetAsync(_baseUrl + "users/" + HttpUtility.HtmlEncode(userId) + "/liked_tweets?" + options.Build(true));
+            BuildRateLimit(res.Headers, Endpoint.TweetsLiked);
+            return ParseArrayData<Tweet>(await res.Content.ReadAsStringAsync());
+        }
+
         #endregion TweetSearch
 
         #region TweetStream

--- a/test/TestLikesByUser.cs
+++ b/test/TestLikesByUser.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using TwitterSharp.Client;
+using TwitterSharp.Request.Option;
+using TwitterSharp.Response.RUser;
+
+namespace TwitterSharp.UnitTests
+{
+    [TestClass]
+    public class TestLikesByUser
+    {
+        [TestMethod]
+        public async Task GetLikesByUser()
+        {
+            var client = new TwitterClient(Environment.GetEnvironmentVariable("TWITTER_TOKEN"));
+            var likedTweets = await client.GetLikedTweets("1611314460399902720", new TweetSearchOptions
+            {
+                Limit = 5
+            });
+            Assert.IsTrue(likedTweets.Any(x => x.Id == "1636441616071180312"));
+        }
+    }
+}


### PR DESCRIPTION
Extend the TwitterClient to allow you retrieve Tweets liked by the supplied User ID.