### PR TITLE
Media variants support

### DIFF
--- a/src/JsonOption/MediaConverter.cs
+++ b/src/JsonOption/MediaConverter.cs
@@ -45,10 +45,27 @@ namespace TwitterSharp.JsonOption
                     Width = TryGetProperty(elem, "width")?.GetInt32(),
                     DurationMs = TryGetProperty(elem, "duration_ms")?.GetInt32(),
                     PreviewImageUrl = TryGetProperty(elem, "preview_image_url")?.GetString(),
-                    Url = TryGetProperty(elem, "url")?.GetString()
+                    Url = TryGetProperty(elem, "url")?.GetString(),
+                    Variants = GetMediaVariants(elem)
                 };
+
                 return media;
             }
+        }
+
+        private MediaVariant[] GetMediaVariants(JsonElement mediaElement)
+        {
+            var mediaVariants = Array.Empty<MediaVariant>();
+
+            if(mediaElement.TryGetProperty("variants", out var variants))
+            {
+                mediaVariants = JsonSerializer.Deserialize<MediaVariant[]>(variants.GetRawText(), new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = new SnakeCaseNamingPolicy()
+                });
+            }
+
+            return mediaVariants;
         }
 
         public override void Write(Utf8JsonWriter writer, Media value, JsonSerializerOptions options)

--- a/src/Request/AdvancedSearch/MediaOption.cs
+++ b/src/Request/AdvancedSearch/MediaOption.cs
@@ -25,6 +25,12 @@
         /// <summary>
         /// URL to the image of the content
         /// </summary>
-        Url
+        Url,
+
+        /// <summary>
+        /// Each media object may have multiple display or playback variants, with different resolutions or formats.
+        /// For videos, each variant will also contain URLs to the video in each format.
+        /// </summary>
+        Variants
     }
 }

--- a/src/Response/RMedia/Media.cs
+++ b/src/Response/RMedia/Media.cs
@@ -10,5 +10,6 @@
         public int? DurationMs { init; get; }
         public string PreviewImageUrl { init; get; }
         public string Url { init; get; }
+        public MediaVariant[] Variants { init; get; }
     }
 }

--- a/src/Response/RMedia/MediaVariant.cs
+++ b/src/Response/RMedia/MediaVariant.cs
@@ -1,0 +1,9 @@
+namespace TwitterSharp.Response.RMedia
+{
+    public class MediaVariant
+    {
+        public int? BitRate { init; get; }
+        public string ContentType { init; get; }
+        public string Url { init; get; }
+    }
+}

--- a/test/TestMedia.cs
+++ b/test/TestMedia.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using TwitterSharp.Client;
 using TwitterSharp.Request.AdvancedSearch;
@@ -77,6 +78,32 @@ namespace TwitterSharp.UnitTests
             Assert.AreEqual(MediaType.Video, a.Attachments.Media[0].Type);
             Assert.IsNotNull(a.Attachments.Media[0].PreviewImageUrl);
             Assert.AreEqual("https://pbs.twimg.com/ext_tw_video_thumb/1237543944570847233/pu/img/kRBUlSd7M7ju_QK1.jpg", a.Attachments.Media[0].PreviewImageUrl);
+        }
+
+        [TestMethod]
+        public async Task GetTweetWithVideoMediaVariants()
+        {
+            var client = new TwitterClient(Environment.GetEnvironmentVariable("TWITTER_TOKEN"));
+            var answer = await client.GetTweetsAsync(new[] { "1688848776612691968" }, new TweetSearchOptions
+            {
+                TweetOptions = new[] { TweetOption.Attachments },
+                MediaOptions = new [] { MediaOption.Variants }
+            });
+            Assert.IsTrue(answer.Length == 1);
+            var a = answer[0];
+            Assert.IsNotNull(a.Attachments);
+            Assert.IsNotNull(a.Attachments.Media);
+            Assert.AreEqual(1, a.Attachments.Media.Length);
+            Assert.AreEqual("13_1688840150338428928", a.Attachments.Media[0].Key);
+            Assert.IsNotNull(a.Attachments.Media[0].Type);
+            Assert.AreEqual(MediaType.Video, a.Attachments.Media[0].Type);
+            Assert.IsNull(a.Attachments.Media[0].PreviewImageUrl);
+
+            Assert.IsNotNull(a.Attachments.Media[0].Variants);
+            Assert.IsTrue(a.Attachments.Media[0].Variants.Length > 0);
+            Assert.IsTrue(a.Attachments.Media[0].Variants.Any(v => v.ContentType == "video/mp4"));
+            Assert.IsTrue(a.Attachments.Media[0].Variants.Any(v => v.BitRate.HasValue));
+            Assert.IsTrue(a.Attachments.Media[0].Variants.All(v => string.IsNullOrWhiteSpace(v.Url) == false));
         }
     }
 }


### PR DESCRIPTION
Support of Twitter media variants
https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/media

It is required, for example, if one needs to obtain url to the video